### PR TITLE
Add dark mode support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Swanson",
-  "version": "2.4",
+  "version": "2.5",
   "description": "Open a new tab, get a Ron Swanson quote",
   "icons": {
     "16": "icons/ron_16.png",

--- a/swanson.html
+++ b/swanson.html
@@ -38,9 +38,32 @@
     text-decoration: none;
   }
 
+  #footer a:hover {
+    text-decoration: underline;
+  }
+
   #footer a:visited {
     color: #222;
     text-decoration: none;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    body {
+      background-color: #151619;
+    }
+
+    h1 {
+      color: #ccc;
+      border-color: #aaa;
+    }
+
+    #footer a {
+      color: #ccc;
+    }
+
+    #footer a:visited {
+      color: #ccc;
+    }
   }
 </style>
 <script src="app.js"></script>


### PR DESCRIPTION
Adds support for dark mode using css `prefers-color-scheme` media query. Also adds underlines to links on hover.

<img width="640" alt="Screen Shot 2019-10-29 at 1 53 23 PM" src="https://user-images.githubusercontent.com/11556475/67800694-b6599880-fa55-11e9-8a5c-dca59a100eaf.png">
